### PR TITLE
NEXT-37504 - fix nested associations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /data
 
 .credentials.toml
+
+*.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,27 @@
 # NEXT-RELEASE
 
+- NEXT-37504 - Fixed the generation of request criteria to support correct nested associations
+
 # v0.7.1
+
 - Moved repository to shopware organization
 
 # v0.7.0
+
 - Fixed bug which caused much worse response times that happened sometimes during concurrent requests
 - Slightly improved the performance and refactored much of the main processing logic to better utilize CPU cores
 
 # v0.6.0
+
 - Added schema / profile validation to ensure the entities + `entity_path` exists in the shop
 
 # v0.5.0
+
 - Added `get_default(name)` function to scripting. It allows lookup of constants like the `Shopware/src/Core/Defaults.php`
 - Fixed import of "To-Many-Associations" when the value is null it will be ignored instead of added to the entity
 
 # v0.4.0
+
 - "To-One-Association" values are now imported correctly
   - Added profile `product_with_manufacturer.yaml` as an example
 - Fixed reported request timings (they were measured wrong, longer than actual)
@@ -24,14 +31,17 @@
 - Removed `sync --verbose` option for now, as it wasn't implemented
 
 # v0.3.0
+
 - Added `associations` entry for schema (used on export only)
 - Implemented proper `entity_path` resolution with optional chaining `?.` for export
 - "To-One-Associations" are now exported correctly
   - The implementation for import is still missing and these fields will be ignored for now
 
 # v0.2.0
+
 - Added very basic `filter` entry for schema (used on export only)
 - Added `sort` entry for schema (used on export only)
 
 # v0.1.0
+
 - Initial release

--- a/src/api/filter.rs
+++ b/src/api/filter.rs
@@ -12,7 +12,7 @@ pub struct Criteria {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub sort: Vec<CriteriaSorting>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub associations: BTreeMap<String, EmptyObject>,
+    pub associations: BTreeMap<String, Criteria>,
 }
 
 impl Default for Criteria {
@@ -39,8 +39,16 @@ impl Criteria {
         self.sort.push(sorting);
     }
 
-    pub fn add_association<S: Into<String>>(&mut self, association: S) {
-        self.associations.insert(association.into(), EmptyObject {});
+    pub fn add_association<S: Into<String>>(&mut self, association_path: S) -> &mut Self {
+        let mut current = self;
+        
+        for part in association_path.into().split('.') {
+            current = current.associations
+                .entry(part.to_string())
+                .or_insert_with(Criteria::default);
+        }
+        
+        current
     }
 }
 

--- a/src/api/filter.rs
+++ b/src/api/filter.rs
@@ -41,13 +41,14 @@ impl Criteria {
 
     pub fn add_association<S: Into<String>>(&mut self, association_path: S) -> &mut Self {
         let mut current = self;
-        
+
         for part in association_path.into().split('.') {
-            current = current.associations
+            current = current
+                .associations
                 .entry(part.to_string())
                 .or_insert_with(Criteria::default);
         }
-        
+
         current
     }
 }
@@ -148,7 +149,7 @@ mod tests {
             ..Default::default()
         };
         criteria.add_association("manufacturer");
-        criteria.add_association("cover");
+        criteria.add_association("cover.media");
 
         let json = serde_json::to_string_pretty(&criteria).unwrap();
         assert_eq!(
@@ -157,8 +158,20 @@ mod tests {
   "limit": 10,
   "page": 2,
   "associations": {
-    "cover": {},
-    "manufacturer": {}
+    "cover": {
+      "limit": 500,
+      "page": 1,
+      "associations": {
+        "media": {
+          "limit": 500,
+          "page": 1
+        }
+      }
+    },
+    "manufacturer": {
+      "limit": 500,
+      "page": 1
+    }
   }
 }"#
         );

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -196,10 +196,16 @@ impl SwClient {
         let response = {
             let _lock = self.in_flight_semaphore.acquire().await.unwrap();
             let start_instant = Instant::now();
-            println!(
-                "fetching page {} of '{}' with limit {}",
-                criteria.page, entity, criteria.limit
-            );
+
+            if let Some(limit) = criteria.limit {
+                println!(
+                    "fetching page {} of '{}' with limit {}",
+                    criteria.page, entity, limit
+                );
+            } else {
+                println!("fetching page {} of '{}'", criteria.page, entity);
+            }
+
             let res = self
                 .client
                 .post(format!(

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -12,11 +12,11 @@ pub async fn export(context: Arc<SyncContext>) -> anyhow::Result<()> {
     if !context.associations.is_empty() {
         println!("Using associations: {:#?}", context.associations);
     }
-    
+
     if !context.schema.filter.is_empty() {
         println!("Using filter: {:#?}", context.schema.filter);
     }
-    
+
     if !context.schema.sort.is_empty() {
         println!("Using sort: {:#?}", context.schema.sort);
     }
@@ -26,11 +26,11 @@ pub async fn export(context: Arc<SyncContext>) -> anyhow::Result<()> {
         .sw_client
         .get_total(&context.schema.entity, &context.schema.filter)
         .await?;
-    
+
     if let Some(limit) = context.limit {
         total = cmp::min(limit, total);
     }
-    
+
     let chunk_limit = cmp::min(Criteria::MAX_LIMIT, total);
     let chunk_count = total.div_ceil(chunk_limit);
     println!(

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -79,7 +79,7 @@ async fn send_request(
 ) -> anyhow::Result<SwListResponse> {
     let mut criteria = Criteria {
         page,
-        limit: chunk_limit,
+        limit: Some(chunk_limit),
         sort: context.schema.sort.clone(),
         filter: context.schema.filter.clone(),
         ..Default::default()


### PR DESCRIPTION
The criteria associations were not nested (generated) correctly.

Before:
```
{
  "defaultBillingAddress.country": EmptyObject,
  "defaultBillingAddress.country.locale": EmptyObject,
  "defaultBillingAddress.salutation": EmptyObject
}
```

After:
```
"defaultBillingAddress": Criteria { 
    ... 
    associations: {
      "country": Criteria { 
        ...
        associations: {
          "locale": Criteria { 
            ...
            associations: {} 
          }
        } 
      }, 
      "salutation": Criteria { 
        ...
        associations: {}   
      }
    }
}
```