### PR TITLE
NEXT-37303 - Refactor away from async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -370,6 +371,12 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-sink"
@@ -390,9 +397,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -640,16 +651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,29 +775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,15 +857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
-dependencies = [
- "bitflags 2.6.0",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +865,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -1049,12 +1019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,15 +1108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,7 +1186,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
- "tokio",
  "toml",
 ]
 
@@ -1348,23 +1302,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4.5.13", features = ["derive", "string"] }
-tokio = { version = "1.39.2", features = ["full"] }
 rayon = "1.10.0"
-reqwest = { version = "0.12.5", features = ["json"] }
+reqwest = { version = "0.12.5", features = ["json", "blocking"] }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.122"
 serde_yaml = "0.9.33"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,6 @@
 //!
 //! Makes heavy use of <https://docs.rs/clap/latest/clap/>
 
-use crate::api::SwClient;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use std::string::ToString;
@@ -85,8 +84,10 @@ pub enum Commands {
     },
 }
 
+pub const DEFAULT_IN_FLIGHT: usize = 10;
+
 fn in_flight_limit_default_as_string() -> String {
-    SwClient::DEFAULT_IN_FLIGHT.to_string()
+    DEFAULT_IN_FLIGHT.to_string()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -98,7 +99,6 @@ pub enum SyncMode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::SwClient;
 
     #[test]
     fn test_basic_cli_arg_parsing() {
@@ -129,7 +129,7 @@ mod tests {
                     file: "./output.csv".into(),
                     limit: None,
                     disable_index: false,
-                    in_flight_limit: SwClient::DEFAULT_IN_FLIGHT,
+                    in_flight_limit: DEFAULT_IN_FLIGHT,
                 },
             }
         );

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -37,9 +37,8 @@ pub struct Credentials {
 }
 
 impl Credentials {
-    pub async fn read_credentials() -> anyhow::Result<Self> {
-        let serialized_credentials = tokio::fs::read_to_string("./.credentials.toml")
-            .await
+    pub fn read_credentials() -> anyhow::Result<Self> {
+        let serialized_credentials = std::fs::read_to_string("./.credentials.toml")
             .context("No .credentials.toml found. Call command auth first.")?;
 
         let credentials: Self = toml::from_str(&serialized_credentials)?;
@@ -71,10 +70,9 @@ pub struct Profile {
 }
 
 impl Profile {
-    pub async fn read_profile(profile_path: impl AsRef<Path>) -> anyhow::Result<Self> {
-        let serialized_profile = tokio::fs::read_to_string(profile_path)
-            .await
-            .context("Provided profile file not found")?;
+    pub fn read_profile(profile_path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let serialized_profile =
+            std::fs::read_to_string(profile_path).context("Provided profile file not found")?;
 
         let profile: Self = serde_yaml::from_str(&serialized_profile)?;
         Ok(profile)


### PR DESCRIPTION
Experiment to move the codebase away from async and just using a threadpool ([Rayon](https://github.com/rayon-rs/rayon)) and parallel iteration where possible.
This removes one of Rusts bigger concepts "async" from the codebase and should make it a lot easier to understand, as it isn't really needed for the use case of this cli tool.

This PR tries to answer the following questions:

### Can the non-async code also be as cleanly written?
I would say yes for the export. ~~The import is currently a bit ugly (because of the manual chunking) but may could be improved further.~~ The import now also works in chunks of the file (and waits for them) instead of pushing the whole file into memory as tasks (like the old implementation).

### Is there a big performance hit by going with a normal thread pool approach?
Some early benchmarks suggest this implementation almost achieves the same performance as the async implementation. It even exceeds it slightly for import. ~~I will add proper benchmarks later~~ I did monitor the performance closely and it seems to roughly stay the same for both import and export (timings fluctuate a lot, depending on system load and how long shopware takes to respond, so no proper benchmarks to show). Feel free to compare this branch to the main branch on your system (remember building with `cargo build --release` when benchmarking).

## How it works now
- Constructs a "Rayon" ThreadPool with the given "in_flight_limit" number of threads (by default 10) at the beginning of execution
- On export it uses a "parallel iterator" from "Rayon" to utilise this thread pool and have at most "in_flight_limit" requests (which block the whole thread) pending at once
- On import it reads from the CSV until it has a big file chunk (of currently 10.000 rows - based on `in_flight_limit`) and then spawns a task into this thread pool for each smaller sync chunk (at most 500), which deserialiazes and makes the sync request. So the same "in_flight_limit" applies here too.

## Open ToDos:
- [x] Throttle reading of the CSV file to wait for sync requests on import (to not load the whole file into memory)
- [x] Cleanup error handling, as I introduced a lot of unwraps with this change
- [x] Try simplifying the import logic again, as it currently is quite verbose (for chunking)