### PR TITLE
Delete old coverage comments from pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,13 @@ jobs:
           name: coverage-html-report
           path: target/llvm-cov/html/
 
+      - name: Delete old coverage comments
+        uses: izhangzhihao/delete-comment@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          delete_user_name: github-actions[bot]
+          issue_number: ${{ github.event.number }}
+
       - uses: actions/github-script@v7
         env:
           ARTIFACT_URL: "${{steps.coverage_upload.outputs.artifact-url}}"


### PR DESCRIPTION
I found it quite annoying to have a comment for every run in the history.

@MalteJanz, for now, I think it’s ok. However, if we introduce a CI that also comments on PRs in the future, we'll need to create a separate bot. This is because it currently deletes all comments made by the github-actions[bot] user.