### PR TITLE
NEXT-37516 - Changed import error handling for database deadlock error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # NEXT-RELEASE
-- NEXT-37303 - [BREAKING] changed `sync` command argument `--schema` `-s` to `--profile` `-p`
+- NEXT-37516 - Added `sync` command argument `-t` `--try-count` which configures the maximum number of tries before a failed but processable request is dropped for the `import` mode
+- NEXT-37303 - [BREAKING] changed `sync` command argument `-s` `--schema` to `-p` `--profile`
 - NEXT-37303 - [BREAKING] Fixed an issue where `row` values were always provided as strings in the deserialize script.
 Now they are converted into their proper types before passed to the script.
 - NEXT-37313 - Implemented re-authentication for API calls to handle expired bearer tokens

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@
 //! Makes heavy use of <https://docs.rs/clap/latest/clap/>
 
 use clap::{Parser, Subcommand};
+use std::num::NonZeroU8;
 use std::path::PathBuf;
 use std::string::ToString;
 
@@ -71,7 +72,7 @@ pub enum Commands {
         #[arg(short, long)]
         limit: Option<u64>,
 
-        // Disable triggering indexer after sync ended successfully
+        /// Disable triggering the indexer after sync ended successfully
         #[arg(value_enum, short, long, default_value = "false")]
         disable_index: bool,
 
@@ -81,6 +82,10 @@ pub enum Commands {
         /// How many requests can be "in-flight" at the same time
         #[arg(short, long, default_value = in_flight_limit_default_as_string())]
         in_flight_limit: usize,
+
+        /// Maximum number of tries a request is executed on a recoverable failure (1..=255)
+        #[arg(short, long, default_value = "10")]
+        try_count: NonZeroU8,
     },
 }
 
@@ -130,6 +135,7 @@ mod tests {
                     limit: None,
                     disable_index: false,
                     in_flight_limit: DEFAULT_IN_FLIGHT,
+                    try_count: NonZeroU8::new(10).unwrap()
                 },
             }
         );


### PR DESCRIPTION
To counter errors like database deadlocks happening during an import of a chunk I reorganized the code in the `sync_chunk` method so that we can use the new `-t` `--try-count` argument of the `sync` command to specify the number of tries a request gets when it returns a processable error.  
Errors that should be caught and processed can be added to the `match` statement in the function.  
New error structures can now be added in the `SwError` *enum*.
New error codes can be added as constants like `ERROR_CODE_DEADLOCK` in the `SwError` *enum*.