### PR TITLE
NEXT-37536 - Added column conversion via column_type mapping option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # NEXT-RELEASE
+- NEXT-37536 - Added the profile mapping option `column_type` with which the column type can be specified if the inferred one leads to conversion t issues. Valid options are `string`, `number` and `boolean`.
 - NEXT-37310 - Added single row import strategy when encountering an error that cannot be handled automatically during a chunk import.
 
 # v0.8.0

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ mappings:
     entity_path: "name"
   - file_column: "product number"
     entity_path: "productNumber"
+    # column type defines the data type for the internal processing of the column data
+    colum_type: "string"
   - file_column: "stock"
     entity_path: "stock"
   - file_column: "tax id"

--- a/profiles/default_customer.yaml
+++ b/profiles/default_customer.yaml
@@ -16,7 +16,8 @@ mappings:
   - file_column: "account type"
     entity_path: "accountType"
   - file_column: "customer number"
-    key: "customer_number"
+    entity_path: "customerNumber"
+    column_type: "string"
   - file_column: "first name"
     entity_path: "firstName"
   - file_column: "last name"
@@ -52,7 +53,8 @@ mappings:
   - file_column: "default billing address street"
     entity_path: "defaultBillingAddress?.street"
   - file_column: "default billing address zip code"
-    key: "default_billing_address_zip_code"
+    entity_path: "defaultBillingAddress?.zipcode"
+    column_type: "string"
   - file_column: "default billing address city"
     entity_path: "defaultBillingAddress?.city"
   - file_column: "default billing address country id"
@@ -74,7 +76,8 @@ mappings:
   - file_column: "default shipping address street"
     entity_path: "defaultShippingAddress?.street"
   - file_column: "default shipping address zip code"
-    key: "default_shipping_address_zip_code"
+    entity_path: "defaultShippingAddress?.zipcode"
+    column_type: "string"
   - file_column: "default shipping address city"
     entity_path: "defaultShippingAddress?.city"
   - file_column: "default shipping address country id"
@@ -90,9 +93,6 @@ mappings:
 
 serialize_script: |
   row = #{
-    customer_number: entity.customerNumber,
-    default_billing_address_zip_code: entity.defaultBillingAddress?.zipCode,
-    default_shipping_address_zip_code: entity.defaultShippingAddress?.zipCode,
     default_group_name: entity.group.translated?.name,
     default_sales_channel_name: entity.salesChannel.translated?.name,
     default_payment_method_name: entity.defaultPaymentMethod.translated?.name
@@ -102,13 +102,6 @@ deserialize_script: |
   let default_language = get_default("LANGUAGE_SYSTEM");
 
   entity = #{
-    customerNumber: `${row.customer_number}`, // TODO: fix conversion (NEXT-37536)
-    defaultBillingAddress: #{
-      zipCode: `${row.default_billing_address_zip_code}`, // TODO: fix conversion (NEXT-37536)
-    },
-    defaultShippingAddress: #{
-      zipCode: `${row.default_shipping_address_zip_code}`, // TODO: fix conversion (NEXT-37536)
-    },
     group: #{
       translations: [#{
         languageId: default_language,

--- a/profiles/default_newsletter_recipient.yaml
+++ b/profiles/default_newsletter_recipient.yaml
@@ -26,10 +26,5 @@ mappings:
   - file_column: "hash"
     entity_path: "hash"
   - file_column: "zipCode"
-    key: "zip_code"
-
-serialize_script: |
-  row.zip_code = entity.zipCode;
-
-deserialize_script: |
-  entity.zipCode = `${row.zip_code}`; // TODO: fix conversion (NEXT-37536)
+    entity_path: "zipCode"
+    column_type: "string"

--- a/profiles/default_order.yaml
+++ b/profiles/default_order.yaml
@@ -11,10 +11,9 @@ mappings:
     entity_path: "languageId"
   - file_column: "sales channel id"
     entity_path: "salesChannelId"
-  - file_column: "state id"
-    entity_path: "stateId"
   - file_column: "order number"
-    key: "order_number"
+    entity_path: "orderNumber"
+    column_type: "string"
   - file_column: "currency factor"
     entity_path: "currencyFactor"
   - file_column: "order date time"
@@ -38,7 +37,8 @@ mappings:
   - file_column: "billing address street"
     entity_path: "billingAddress?.street"
   - file_column: "billing address zip code"
-    key: "billing_address_zipcode"
+    entity_path: "billingAddress?.zipcode"
+    column_type: "string"
   - file_column: "billing address company"
     entity_path: "billingAddress?.company"
   - file_column: "billing address city"
@@ -73,14 +73,19 @@ mappings:
     key: "price_position_price"
   - file_column: "price tax rates"
     key: "price_tax_rates"
+    column_type: "string"
   - file_column: "price tax percentages"
     key: "price_tax_percentages"
+    column_type: "string"
   - file_column: "price calculated taxes"
     key: "price_calculated_taxes"
+    column_type: "string"
   - file_column: "price calculated tax prices"
     key: "price_calculated_tax_prices"
+    column_type: "string"
   - file_column: "price calculated tax rates"
     key: "price_calculated_tax_rates"
+    column_type: "string"
   - file_column: "shipping cost quantity"
     key: "shipping_cost_quantity"
   - file_column: "shipping cost unit price"
@@ -89,14 +94,19 @@ mappings:
     key: "shipping_cost_total_price"
   - file_column: "shipping cost tax rates"
     key: "shipping_cost_tax_rates"
+    column_type: "string"
   - file_column: "shipping cost tax percentages"
     key: "shipping_cost_tax_percentages"
+    column_type: "string"
   - file_column: "shipping cost calculated taxes"
     key: "shipping_cost_calculated_taxes"
+    column_type: "string"
   - file_column: "shipping cost calculated tax prices"
     key: "shipping_cost_calculated_tax_prices"
+    column_type: "string"
   - file_column: "shipping cost calculated tax rates"
     key: "shipping_cost_calculated_tax_rates"
+    column_type: "string"
 
 serialize_script: |
   fn encode_values(arr, value_name) {
@@ -114,8 +124,6 @@ serialize_script: |
   }
 
   row = #{
-    order_number: entity.orderNumber,
-    billing_address_zipcode: entity.billingAddress?.zipcode,
     item_rounding_decimals: entity.itemRounding?.decimals,
     item_rounding_interval: entity.itemRounding?.interval,
     item_rounding_round_for_net: entity.itemRounding?.roundForNet,
@@ -214,10 +222,6 @@ deserialize_script: |
   }
 
   entity = #{
-    orderNumber: `${row.order_number}`, // TODO: fix conversion (NEXT-37536)
-    billingAddress: #{
-      zipcode: `${row.billing_address_zipcode}`, // TODO: fix conversion (NEXT-37536)
-    },
     itemRounding: #{
       decimals: row.item_rounding_decimals,
       interval: row.item_rounding_interval,

--- a/profiles/default_product.yaml
+++ b/profiles/default_product.yaml
@@ -23,6 +23,7 @@ mappings:
     entity_path: "cover"
   - file_column: "product number"
     entity_path: "productNumber"
+    column_type: "string"
   - file_column: "active"
     entity_path: "active"
   - file_column: "stock"

--- a/profiles/default_product_variants.yaml
+++ b/profiles/default_product_variants.yaml
@@ -26,6 +26,7 @@ mappings:
     entity_path: "cover"
   - file_column: "product number"
     entity_path: "productNumber"
+    column_type: "string"
   - file_column: "active"
     entity_path: "active"
   - file_column: "stock"

--- a/profiles/default_promotion_discount.yaml
+++ b/profiles/default_promotion_discount.yaml
@@ -18,14 +18,9 @@ mappings:
   - file_column: "sorter key"
     entity_path: "sorterKey"
   - file_column: "applier key"
-    key: "applier_key"
+    entity_path: "applierKey"
+    column_type: "string"
   - file_column: "usage key"
     entity_path: "usageKey"
   - file_column: "picker key"
     entity_path: "pickerKey"
-
-serialize_script: |
-  row.applier_key = entity.applierKey;
-
-deserialize_script: |
-  entity.applierKey = `${row.applier_key}`; // TODO: fix conversion (NEXT-37536)

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -132,6 +132,7 @@ impl Mapping {
 pub struct EntityPathMapping {
     pub file_column: String,
     pub entity_path: String,
+    pub column_type: Option<ColumnType>,
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize)]
@@ -139,6 +140,15 @@ pub struct EntityScriptMapping {
     pub file_column: String,
     /// used as an identifier inside the script
     pub key: String,
+    pub column_type: Option<ColumnType>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ColumnType {
+    String,
+    Number,
+    Boolean,
 }
 
 #[cfg(test)]

--- a/src/data/transform/script.rs
+++ b/src/data/transform/script.rs
@@ -45,7 +45,8 @@ impl ScriptingEnvironment {
                 .get(column_index)
                 .context("failed to get column of row")?;
 
-            let json_value = get_json_value_from_string(raw_value);
+            let json_value = get_json_value_from_string(raw_value, &mapping.column_type)?;
+
             let script_value = rhai::serde::to_dynamic(json_value)
                 .context("failed to convert CSV value into script value")?;
 
@@ -326,10 +327,12 @@ mod tests {
                 Mapping::ByScript(EntityScriptMapping {
                     file_column: "bar".to_string(),
                     key: "bar_key".to_string(),
+                    column_type: None,
                 }),
                 Mapping::ByScript(EntityScriptMapping {
                     file_column: "number + 1".to_string(),
                     key: "number_plus_one".to_string(),
+                    column_type: None,
                 }),
             ],
             ..Default::default()

--- a/src/data/validate.rs
+++ b/src/data/validate.rs
@@ -50,6 +50,7 @@ pub fn validate_paths_for_entity(
         let mapping = Mapping::ByPath(EntityPathMapping {
             file_column: path_mapping.file_column.clone(),
             entity_path: path,
+            column_type: path_mapping.column_type.clone(),
         });
 
         // validate the new mapping
@@ -70,6 +71,7 @@ mod tests {
         let mapping = vec![Mapping::ByPath(EntityPathMapping {
             file_column: "manufacturer id".to_string(),
             entity_path: "manufacturerId".to_string(),
+            column_type: None,
         })];
         let api_schema = json!({
             "product": {
@@ -93,6 +95,7 @@ mod tests {
         let mapping = vec![Mapping::ByPath(EntityPathMapping {
             file_column: "manufacturer id".to_string(),
             entity_path: "manufacturerId".to_string(),
+            column_type: None,
         })];
         let api_schema = json!({
             "product": {
@@ -116,6 +119,7 @@ mod tests {
         let mapping = vec![Mapping::ByPath(EntityPathMapping {
             file_column: "manufacturer id".to_string(),
             entity_path: "manufacturerId".to_string(),
+            column_type: None,
         })];
         let api_schema = json!({
             "product": {
@@ -143,6 +147,7 @@ mod tests {
         let mapping = vec![Mapping::ByPath(EntityPathMapping {
             file_column: "manufacturer name".to_string(),
             entity_path: "manufacturer.name".to_string(),
+            column_type: None,
         })];
         let api_schema = json!({
             "product": {
@@ -172,6 +177,7 @@ mod tests {
         let mapping = vec![Mapping::ByPath(EntityPathMapping {
             file_column: "manufacturer name".to_string(),
             entity_path: "manufacturer.name".to_string(),
+            column_type: None,
         })];
         let api_schema = json!({
             "product": {
@@ -208,6 +214,7 @@ mod tests {
         let mapping = vec![Mapping::ByPath(EntityPathMapping {
             file_column: "manufacturer name".to_string(),
             entity_path: "manufacturer?.name".to_string(),
+            column_type: None,
         })];
         let api_schema = json!({
             "product": {
@@ -244,6 +251,7 @@ mod tests {
         let mapping = vec![Mapping::ByPath(EntityPathMapping {
             file_column: "manufacturer name".to_string(),
             entity_path: "manufacturer?.name".to_string(),
+            column_type: None,
         })];
         let api_schema = json!({
             "product": {
@@ -282,6 +290,7 @@ mod tests {
         let mapping = vec![Mapping::ByPath(EntityPathMapping {
             file_column: "tax country".to_string(),
             entity_path: "tax.country.name".to_string(),
+            column_type: None,
         })];
         let api_schema = json!({
             "product": {


### PR DESCRIPTION
# Description
When inferring the type of a value from the target file during an import the error that the API needs some other type occurred.
E.g.:  
The product number 42 was converted to a number value, but the API expected a string.

# Solution
I've added the mapping option `column_type` with which the user can specify the type of every cell in the column.  
Valid options currently are `string`, `boolean` and `number`.  
The issue mentioned could for example be solved like this:
```yaml
entity: product

mapping:
  - file_column: "product number"
    entity_path: "productNumber"
    column_type: "string"
```
The only tripwire is that the user could specify a wrong type, e.g. adds the `number` type on the active field (boolean) of the product which will obviously fail whilst importing.   
The import for that specific chunk will be aborted with an error message similar to this:
> sync chunk 1000..=1499 (size=500) failed to deserialize:
> error in row 1000: error in column "active": failed to convert true into a number; make sure that you use the column types correctly

The export will be unaffected.